### PR TITLE
[feat] ImageResponseSQS에 일기 생성 성공 혹은 실패 시의 메시지를 전송하는 로직 추가

### DIFF
--- a/fourtooncookie-diaryimage-ai-apply-lambda/config.py
+++ b/fourtooncookie-diaryimage-ai-apply-lambda/config.py
@@ -3,7 +3,7 @@ import os
 OPENAI_API_KEY = os.environ['OPENAI_API_KEY']
 PORTKEY_API_KEY = os.environ['PORTKEY_API_KEY']
 S3_BUCKET_NAME = os.environ['S3_BUCKET_NAME']
-SQS_QUEUE_URL = os.environ['SQS_QUEUE_URL']
+IMAGE_RESPONSE_SQS_QUEUE_URL = os.environ['IMAGE_RESPONSE_SQS_QUEUE_URL']
 
 
 from openai import OpenAI
@@ -62,6 +62,6 @@ vision_request_services: dict[str, VisionRequestService] = {
         openai, s3client, S3_BUCKET_NAME, ScenesAsImagePromptConvertExecuter()
         ),
     "STABLE_DIFFUSION": SQSStableDiffusionVisionRequestService(
-        sqsclient, SQS_QUEUE_URL, SceneAsWordsConvertExecuter()
+        sqsclient, STABLE_DIFFUSION_SQS_QUEUE_URL, SceneAsWordsConvertExecuter()
         )
 }

--- a/fourtooncookie-diaryimage-ai-apply-lambda/config.py
+++ b/fourtooncookie-diaryimage-ai-apply-lambda/config.py
@@ -4,6 +4,7 @@ OPENAI_API_KEY = os.environ['OPENAI_API_KEY']
 PORTKEY_API_KEY = os.environ['PORTKEY_API_KEY']
 S3_BUCKET_NAME = os.environ['S3_BUCKET_NAME']
 IMAGE_RESPONSE_SQS_QUEUE_URL = os.environ['IMAGE_RESPONSE_SQS_QUEUE_URL']
+STABLE_DIFFUSION_SQS_QUEUE_URL = os.environ['STABLE_DIFFUSION_SQS_QUEUE_URL']
 
 
 from openai import OpenAI
@@ -27,6 +28,8 @@ import boto3
 s3client: boto3.client = boto3.client('s3')
 sqsclient: boto3.client = boto3.client('sqs', region_name='ap-northeast-2')
 
+from sqs.image_response_sqs_service import ImageResponseSQSService
+image_response_sqs_service: ImageResponseSQSService = ImageResponseSQSService(sqsclient, IMAGE_RESPONSE_SQS_QUEUE_URL)
 
 from llm.llm_service import LLMService
 from llm.gpt4o_llm_service import GPT4oLLMService

--- a/fourtooncookie-diaryimage-ai-apply-lambda/lambda_function.py
+++ b/fourtooncookie-diaryimage-ai-apply-lambda/lambda_function.py
@@ -28,4 +28,5 @@ def lambda_handler(body, context):
         return True
     except Exception as e:
         print(e)
+        image_response_sqs_service.send_image_failure_response(diary_id) # 실패 시 SQS에 실패 메시지 전송
         return False

--- a/fourtooncookie-diaryimage-ai-apply-lambda/lambda_function.py
+++ b/fourtooncookie-diaryimage-ai-apply-lambda/lambda_function.py
@@ -13,7 +13,11 @@ def lambda_handler(body, context):
         character_base_prompt = character['basePrompt']
 
         content = body['content']
-
+    except Exception as e:
+        print(e)
+        return False
+    
+    try:
         # LLM과 prompt 활용하여 내용 정체
         scenes = scene_generator.generate_scenes(content)
 

--- a/fourtooncookie-diaryimage-ai-apply-lambda/sqs/image_response_sqs_service.py
+++ b/fourtooncookie-diaryimage-ai-apply-lambda/sqs/image_response_sqs_service.py
@@ -1,0 +1,29 @@
+import boto3
+import json
+
+class ImageResponseSQSService():
+
+    __sqs: boto3.client
+    __queue_url: str
+
+    def __init__(self, sqs, queue_url):
+        self.__sqs = sqs
+        self.__queue_url = queue_url
+    
+    def send_image_success_response(self, diary_id: int):
+        self.__sqs.send_message(
+            QueueUrl=self.__queue_url,
+            MessageBody=json.dumps({
+                "diaryId": diary_id,
+                "status": True
+            })
+        )
+    
+    def send_image_failure_response(self, diary_id: int):
+        self.__sqs.send_message(
+            QueueUrl=self.__queue_url,
+            MessageBody=json.dumps({
+                "diaryId": diary_id,
+                "status": False
+            })
+        )

--- a/fourtooncookie-diaryimage-ai-apply-lambda/sqs/image_response_sqs_service.py
+++ b/fourtooncookie-diaryimage-ai-apply-lambda/sqs/image_response_sqs_service.py
@@ -11,19 +11,23 @@ class ImageResponseSQSService():
         self.__queue_url = queue_url
     
     def send_image_success_response(self, diary_id: int):
-        self.__sqs.send_message(
-            QueueUrl=self.__queue_url,
-            MessageBody=json.dumps({
-                "diaryId": diary_id,
-                "status": True
-            })
-        )
+        for grid_position in range(4):
+            self.__sqs.send_message(
+                QueueUrl=self.__queue_url,
+                MessageBody=json.dumps({
+                    "diaryId": diary_id,
+                    "gridPosition": grid_position,
+                    "status": True
+                })
+            )
     
     def send_image_failure_response(self, diary_id: int):
-        self.__sqs.send_message(
-            QueueUrl=self.__queue_url,
-            MessageBody=json.dumps({
-                "diaryId": diary_id,
-                "status": False
-            })
-        )
+        for grid_position in range(4):
+            self.__sqs.send_message(
+                QueueUrl=self.__queue_url,
+                MessageBody=json.dumps({
+                    "diaryId": diary_id,
+                    "gridPosition": grid_position,
+                    "status": False
+                })
+            )

--- a/fourtooncookie-diaryimage-ai-apply-lambda/sqs/image_response_sqs_service.py
+++ b/fourtooncookie-diaryimage-ai-apply-lambda/sqs/image_response_sqs_service.py
@@ -17,7 +17,7 @@ class ImageResponseSQSService():
                 MessageBody=json.dumps({
                     "diaryId": diary_id,
                     "gridPosition": grid_position,
-                    "status": True
+                    "isSuccess": True
                 })
             )
     
@@ -28,6 +28,6 @@ class ImageResponseSQSService():
                 MessageBody=json.dumps({
                     "diaryId": diary_id,
                     "gridPosition": grid_position,
-                    "status": False
+                    "isSuccess": False
                 })
             )

--- a/fourtooncookie-diaryimage-ai-apply-lambda/visionrequest/dall_e_3/dall_e_3_vision_request_service.py
+++ b/fourtooncookie-diaryimage-ai-apply-lambda/visionrequest/dall_e_3/dall_e_3_vision_request_service.py
@@ -35,6 +35,10 @@ class DallE3VisionRequestService(VisionRequestService):
         image_base64 = response.data[0].b64_json
         image = self.__decode_base64_image(image_base64)
 
+        self.__upload_image(diary_id, image)
+    
+
+    def __upload_image(self, diary_id: int, image: Image):
         top_left, top_right, bottom_left, bottom_right = self.__split_image(image)
 
         for i, image in enumerate([top_left, top_right, bottom_left, bottom_right]):


### PR DESCRIPTION
# [feat] ImageResponseSQS에 일기 생성 성공 혹은 실패 시의 메시지를 전송하는 로직 추가
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-407
---
* 구현 내용

- ImageResponseSQSService 구현
- DallE3VisionRequestService에서 이미지 생성 성공 및 S3 업로드 성공 시 SQS에 성공 메시지를 보내는 로직 구성
- lambda_function에서 이미지 생성 실패 시(오류 발생 시) SQS에 실패 메시지를 보내는 로직 구성

* 추가 발생한 문제(논의 사항)

- Stable Diffusion GPU 서버 코드에서도 ImageResponseSQSService 관련 로직을 구성해야 합니다.
- 추후에 gridPosition의 범위가 늘어나면 이에 대한 로직 수정이 필요합니다.